### PR TITLE
Closes issue#894 bug:about-us-page-link-solved/ankit0369 [under hacktoberfest23]

### DIFF
--- a/Pages/Team/team.html
+++ b/Pages/Team/team.html
@@ -30,7 +30,7 @@
         <ul class="nav_link">
           <li><a href="../../index.html">Home</a></li>
           <li><a href="../../index.html">Services</a></li>
-          <li><a href="about.html">About us</a></li>
+          <li><a href="../About Page/about.html">About us</a></li>
           <li><a href="../Team/team.html">Team</a></li>
           <li><a href="../contact/contact.html">Contact us</a></li>
         </ul>


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->
closes #894 
## Fixes Issue
This PR fixes the issue #894 . link of about-us page is linked correctly on team page.


<!-- Example: Closes #31 -->

## Changes proposed


<!-- List all the proposed changes in your PR -->
1. about us page is correctly linked on the team page. Previously when we go to team page. and click on about us 404 error occurs. This PR solve this issue

## Screenshots

<img width="881" alt="image" src="https://github.com/codervivek5/VigyBag/assets/98079557/1c0d2789-a1fc-40aa-9b9f-8edcc72e3c24">

![image](https://github.com/codervivek5/VigyBag/assets/98079557/9f4986b9-2897-43d3-8732-0dacaf5c47fc)



<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
