### PR TITLE
Fix message input visibility in Contact Us page

### DIFF
--- a/Pages/contact/contact.css
+++ b/Pages/contact/contact.css
@@ -168,7 +168,7 @@ body {
   font-size: 16px;
   margin-top: 3px;
   padding: 6px;
-  color: #e4e4ee;
+  color: #0e0e0f;
 }
 
 .input-box label {


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

<!-- Remove this section if not applicable -->
closes #937 
<!-- Example: Closes #31 -->

## Changes proposed
This pull request addresses issue #937, where the text typed into the message input box in the "Contact Us" section is not visible due to insufficient contrast with the background. The proposed changes aim to improve the visibility by adjusting the text color within the message input box.
<!-- List all the proposed changes in your PR -->

## Screenshots
![Screenshot 2024-01-26 224229](https://github.com/codervivek5/VigyBag/assets/142984776/9c15f9c3-3ed9-4e58-a440-838a82fe199e)

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
working under JWOC
