### PR TITLE
Fix Typo in FAQ Section: Capitalize "i" in "How do i track my orders?"

### DIFF
--- a/index.html
+++ b/index.html
@@ -2059,7 +2059,7 @@
     </div>
     <div class="c" data-aos-duration="1800" data-aos="fade-up">
       <input type="checkbox" id="faq-4" />
-      <h1><label for="faq-4">How do i track my orders ?</label></h1>
+      <h1><label for="faq-4">How do I track my orders ?</label></h1>
       <div class="p">
         <p>
         1. Open the App:


### PR DESCRIPTION
Closes #1249

## Changes proposed

- Corrected the typo in the "Frequently Asked Questions" section on the home page.
- Changed "How do i track my orders?" to "How do I track my orders?".

## Screenshots

### Before
![typo issue](https://github.com/codervivek5/VigyBag/assets/139670144/5d0c1f43-8ea4-447e-be5f-d643931825b5)


### After
<img width="926" alt="resolved typo" src="https://github.com/codervivek5/VigyBag/assets/139670144/63e730f1-f10f-40e2-b6e0-d8325bfa0904">


## Note to reviewers

I have verified that no one else has created this issue and resolved it under GSSoC `24.
