### PR TITLE
Show shipping FREE when order is above ₹500

### DIFF
--- a/src/components/Order/OrderSummary.jsx
+++ b/src/components/Order/OrderSummary.jsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { useSelector } from "react-redux";
 
 const currencyFormatter = new Intl.NumberFormat('en-IN', { style: 'currency', currency: 'INR' });
@@ -18,7 +19,7 @@ function OrderSummary() {
 
     let shipping = calculateShipping(itemsTotal, shippingThreshold, shippingRate);
     let total = itemsTotal + shipping;
-
+    
     if (itemsTotal === 0) {
         return (
         <div className="mb-5">
@@ -52,7 +53,11 @@ function OrderSummary() {
                     ))}
                     <li className="flex items-center justify-between gap-5 font-bold">
                         <span>Shipping</span>
-                        <span>{currencyFormatter.format(shipping)}</span>
+                        {shipping === 0.00 ? (
+                            <span className="text-green-600">FREE</span>
+                        ) : (
+                            <span>{currencyFormatter.format(shipping)}</span>
+                        )}
                     </li>
                     <hr />
                     <li className="flex items-center justify-between gap-5 font-bold text-xl">

--- a/src/components/Order/OrderSummary.jsx
+++ b/src/components/Order/OrderSummary.jsx
@@ -54,7 +54,7 @@ function OrderSummary() {
                     <li className="flex items-center justify-between gap-5 font-bold">
                         <span>Shipping</span>
                         {shipping === 0.00 ? (
-                            <span className="text-green-600">FREE</span>  {/*FREE display*/}
+                            <span className="text-green-600">FREE</span>  /*FREE display*/
                         ) : (
                             <span>{currencyFormatter.format(shipping)}</span>
                         )}

--- a/src/components/Order/OrderSummary.jsx
+++ b/src/components/Order/OrderSummary.jsx
@@ -54,7 +54,7 @@ function OrderSummary() {
                     <li className="flex items-center justify-between gap-5 font-bold">
                         <span>Shipping</span>
                         {shipping === 0.00 ? (
-                            <span className="text-green-600">FREE</span>  //FREE display
+                            <span className="text-green-600">FREE</span>  {/*FREE display*/}
                         ) : (
                             <span>{currencyFormatter.format(shipping)}</span>
                         )}

--- a/src/components/Order/OrderSummary.jsx
+++ b/src/components/Order/OrderSummary.jsx
@@ -54,7 +54,7 @@ function OrderSummary() {
                     <li className="flex items-center justify-between gap-5 font-bold">
                         <span>Shipping</span>
                         {shipping === 0.00 ? (
-                            <span className="text-green-600">FREE</span>
+                            <span className="text-green-600">FREE</span>  //FREE display
                         ) : (
                             <span>{currencyFormatter.format(shipping)}</span>
                         )}

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -1,11 +1,8 @@
 import React, { useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
 import CategoryCard from "../../components/HomPageCard/CategoryCard";
 import LatestInMarketCard from "../../components/HomPageCard/LatestInMarketCard";
 import background from "../../assets/background.png";
 import app from "../../assets/app.png";
-import googlePlay from "../../assets/google-play.png";
-import mobile from "../../assets/mobile.png";
 import { Link } from "react-router-dom";
 import SearchBar from "../../pages/Home/SearchBar";
 
@@ -287,7 +284,7 @@ const Home = () => {
                         padding: "10px",
                         marginBottom: "10px",
                         border: "1px solid #ccc",
-                        "@media (max-width: 780px)": {
+                        "@media (maxWidth: 780px)": {
                           width: "80%",
                         },
                       }}


### PR DESCRIPTION
Modified OrderSummary.jsx file to display FREE when shipping charges are 0.
Modified Home.jsx file for syntax errors in js format.

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue #1774 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

<!-- List all the proposed changes in your PR -->
Modified OrderSummary.jsx file to display FREE when itemTotal is above 500 and shipping charges are 0.

## Screenshots

<!-- Add all the screenshots which support your changes -->
![Screenshot 2024-07-12 215423](https://github.com/user-attachments/assets/58380d9b-7ec1-49c2-a9e0-8a153d53994f)


## Note to reviewers

<!-- Add notes to reviewers if applicable -->
The Home.jsx file was modified because it was giving syntax error for js. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved `OrderSummary` component to display "FREE" for zero shipping cost, enhancing clarity on shipping fees.

- **Refactor**
  - Updated CSS media query property from `max-width` to `maxWidth` in the Home page for better consistency.

- **Chores**
  - Removed unused imports (`useNavigate`, `googlePlay`, `mobile`) from the Home page to clean up the code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->