### PR TITLE
🛠️ FIX : First Name Field validation in Contact us page

### DIFF
--- a/src/User/pages/Contacts/Contact.jsx
+++ b/src/User/pages/Contacts/Contact.jsx
@@ -100,7 +100,13 @@ function ContactPage() {
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
               <div>
                 <label htmlFor="fname" className="block mb-2">First Name</label>
-                <input type="text" id="fname" className="w-full p-2 border rounded" placeholder="Enter your first name" minLength={3} required/>
+                <input type="text" id="fname" className="w-full p-2 border rounded" placeholder="Enter your first name" minLength={3} required pattern="[a-zA-Z ]+"
+              onInvalid={(e) => {
+                e.target.setCustomValidity('Numbers and Symbols are not allowed.');
+              }}
+              onInput={(e) => {
+                e.target.setCustomValidity('');
+              }}/>
               </div>
               <div>
                 <label htmlFor="lname" className="block mb-2">Last Name</label>


### PR DESCRIPTION

## Changes proposed

The "First Name" field on the Contact us page only accepts alphabetical letters (a-z, A-Z). Currently, the field does not allow users to input symbols and special characters, which may lead to invalid or spam submissions.



## Fixes Issue

Closes #2331


## Screenshots

Before 
![image](https://github.com/user-attachments/assets/f106871a-c1ae-49b4-916f-42862980bc4c)


After 
![image](https://github.com/user-attachments/assets/da3717ea-91e2-4e10-b38e-6f9ae848daf2)

# Checklist
- [X] I agree to follow this project's Code of Conduct
- [X] I'm a GSSOC'24 contributor
- [X] I'm a hacktoberfest 2024 contributor



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced contact form with improved validation for phone numbers, first names, and messages.
	- Added a dropdown for selecting a country code.

- **Bug Fixes**
	- Implemented error messages for invalid phone number inputs using SweetAlert2.

- **User Experience Improvements**
	- Input restrictions for first name and phone number to ensure valid entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->