### PR TITLE
🛠️ FIX : Last Name Field validation in Contact us page

### DIFF
--- a/src/User/pages/Contacts/Contact.jsx
+++ b/src/User/pages/Contacts/Contact.jsx
@@ -104,7 +104,13 @@ function ContactPage() {
               </div>
               <div>
                 <label htmlFor="lname" className="block mb-2">Last Name</label>
-                <input type="text" id="lname" className="w-full p-2 border rounded" placeholder="Enter your last name" minLength={3} required />
+                <input type="text" id="lname" className="w-full p-2 border rounded" placeholder="Enter your last name" minLength={3} required pattern="[a-zA-Z ]+"
+              onInvalid={(e) => {
+                e.target.setCustomValidity('Numbers and Symbols are not allowed.');
+              }}
+              onInput={(e) => {
+                e.target.setCustomValidity('');
+              }}/>
               </div>
             </div>
             <div className="mb-4">


### PR DESCRIPTION
## Changes proposed

The "Last Name" field on the Contact Us page only accepts alphabetical letters (a-z, A-Z). Currently, the field does not allow users to input symbols and special characters, which may lead to invalid or spam submissions.



## Fixes Issue

Closes #2332


## Screenshots

Before 
![image](https://github.com/user-attachments/assets/07b753f7-e1ca-44bc-a607-847218c8038f)


After 
![image](https://github.com/user-attachments/assets/fd47155a-ff7f-43fa-9b9f-ff7f2ba522cf)

# Checklist
- [X] I agree to follow this project's Code of Conduct
- [X] I'm a GSSOC'24 contributor
- [X] I'm a hacktoberfest 2024 contributor



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a dropdown for selecting the country in the contact form.
	- Enhanced phone number validation with length checks and numeric input restrictions.
	- Updated last name field to allow only alphabetic characters and spaces.
	- Added minimum length requirement for the message textarea.

- **Bug Fixes**
	- Improved form validation feedback with error messages for invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->