### PR TITLE
Update WishlistEmpty Explore button color

### DIFF
--- a/src/User/pages/Order/WishlistEmpty.jsx
+++ b/src/User/pages/Order/WishlistEmpty.jsx
@@ -4,7 +4,7 @@ import empty from "../../../assets/emptyWishlist.png";
 
 const WishlistEmpty = () => {
   const buttonBgClass =
-    "bg-green-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition duration-300 ease-in-out mt-3";
+    "bg-green-600 text-white px-4 py-2 rounded-lg hover:bg-green-700 transition duration-300 ease-in-out mt-3";
 
   return (
     <div className="flex flex-col pt-2">

--- a/src/User/pages/Order/WishlistEmpty.jsx
+++ b/src/User/pages/Order/WishlistEmpty.jsx
@@ -4,7 +4,7 @@ import empty from "../../../assets/emptyWishlist.png";
 
 const WishlistEmpty = () => {
   const buttonBgClass =
-    "bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition duration-300 ease-in-out mt-3";
+    "bg-green-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition duration-300 ease-in-out mt-3";
 
   return (
     <div className="flex flex-col pt-2">


### PR DESCRIPTION
Updated the color of the mismatched button to align with the style of similar buttons and the overall site theme.

## Fixes Issue

Closes #2312 

## Changes proposed

- Updated the Wishlist "Explore" button color to match the overall theme of the site.
- Ensured the color is consistent with other similar buttons to maintain visual coherence.

## Screenshots

|        BEFORE        |
![image](https://github.com/user-attachments/assets/226b9c11-f98f-494d-b7d4-a65db46c1b1c)
Now color is set to green like rest of the site theme

## Note to reviewers

The button's updated color brings it in line with the theme and design standards, enhancing user experience.

@codervivek5  If change acceptable kindly merge and assign me this PR and add labels : **hacktoberfest-accepted, gssoc-ext, any level label** suitable



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Updated the background color of the button in the Wishlist Empty component from blue to green for improved visibility and enhanced user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->