### PR TITLE
updated background of got to top button

### DIFF
--- a/src/User/components/GoToTop/top.css
+++ b/src/User/components/GoToTop/top.css
@@ -29,7 +29,8 @@
     background-color: #005a01;
     transform: scale(1.1);
   }
-  
+ 
+
   .circular-progress {
     position: absolute;
     width: 100%;
@@ -57,5 +58,5 @@
     color: white;
     font-size: 24px;
     z-index: 1; /* Ensure it is above the circle */
-    background-color: #16a34a;
+    background-color:transparent;
   }


### PR DESCRIPTION
I am a contributer from #OSCI 
Successfully solved a minor bug of the top-btn--icon where its background was not changing when cursor is hovered over it.

## Fixes Issue
Closes: #2443 



##before
<img width="230" height="324" alt="image" src="https://github.com/user-attachments/assets/d0546d6c-ecb9-4582-a392-a509ca6ef356" />

##after
<img width="150" height="292" alt="image" src="https://github.com/user-attachments/assets/5ec7b157-bfe1-409b-90d4-46aed251e0cf" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual appearance of the “Go to Top” button icon by removing its solid green background. The icon now uses a transparent background, presenting a cleaner, flatter look focused on the icon itself.
  * Minor formatting adjustments to CSS spacing with no impact on behavior or layout.
* **Bug Fixes**
  * None.
* **Chores**
  * None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->