### PR TITLE
footer link redirections fixed

### DIFF
--- a/src/Admin/Pages/ProductForm.jsx
+++ b/src/Admin/Pages/ProductForm.jsx
@@ -187,7 +187,7 @@ const ProductForm = () => {
               label="Country of Origin"
               placeholder="Manufacturing country"
             />
-            <InputField label="Certifications" placeholder="If any" />
+            <InputField label="Certification" placeholder="If any" />
             <InputField label="Tags" placeholder="Comma-separated tags" />
           </>
         );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,7 +27,7 @@ import Help from "./User/pages/Help/Help";
 import Privacy from "./User/pages/Privacy-Policy/Privacy";
 import Payment from "./User/pages/Payment/Payment";
 import ReturnAndCancellation from "./User/pages/ReturnAndCancellation/returnAndCancellation";
-import EPRPage from "./User/pages/EPRPage/EPR_Page";
+import EPR_Page from "./User/pages/EPRPage/EPR_Page";
 import FAQ from "./User/pages/FAQ/Faq";
 import PrivateRoute from "./PrivateRoute";
 import TermsAndConditions from "./User/pages/TermsAndCondition/TermsAndCondition";
@@ -40,6 +40,7 @@ import ServicePage from "./User/pages/Service-Page/service.jsx";
 import Shipping from "./User/pages/Shipping/shipping";
 import GiftCard from "./User/pages/Gift-Card/gift-card.jsx";
 import Payment_Policy from "./User/pages/Payment-Policy/payment-policy.jsx";
+import Certification from "./User/pages/Certifications/Certifications.jsx";
 // Admin components
 import AdminVerificationPage from "./User/pages/Admin-Verification/Admin.jsx";
 import AdminLayout from "./Admin/AdminLayout";
@@ -47,7 +48,6 @@ import AdminLogin from "./Admin/Pages/AdminLogin";
 import VigyForm from "./Admin/Pages/VigyForm";
 import AdminPanel from "./Admin/Pages/AdminPanel";
 import ProductForm from "./Admin/Pages/ProductForm";
-import Certifications from "./User/pages/Certifications/Certifications";
 
 // Latest In Market
 import LatestInMarket from "./User/pages/Latest_in_the_Market/LatestInMarket";
@@ -186,7 +186,7 @@ export default function App() {
           />
           <Route path="payment-policy" element={<Payment_Policy />} />
           {/* Return and Cancellation page route */}
-          <Route path="epr" element={<EPRPage />} /> {/* EPR page route */}
+          <Route path="epr-compliance" element={<EPR_Page />} /> {/* EPR page route */}
           <Route path="career" element={<CareerPage />} />
           <Route path="service" element={<ServicePage />} />
           <Route path="shipping" element={<Shipping />} />
@@ -209,7 +209,7 @@ export default function App() {
             {/* Order cancellation route */}
             <Route path="orderDetails" element={<OrderDetails />} />
             {/* Order details route */}
-            <Route path="my-orders" element={<MyOrders />} />
+            <Route path="myorders" element={<MyOrders />} />
             {/* My orders route */}
             <Route path="checkout" element={<Checkout />} />
             {/* Checkout route */}
@@ -240,7 +240,7 @@ export default function App() {
             {/* Dashboard Profile route */}
           </Route>
           {/* Certifications page route */}
-          <Route path="certificate" element={<Certifications />} />
+          <Route path="certification" element={<Certification />} />
           {/* 404 Error page route */}
           <Route path="*" element={<Error />} />
         </Route>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -40,7 +40,8 @@ import ServicePage from "./User/pages/Service-Page/service.jsx";
 import Shipping from "./User/pages/Shipping/shipping";
 import GiftCard from "./User/pages/Gift-Card/gift-card.jsx";
 import Payment_Policy from "./User/pages/Payment-Policy/payment-policy.jsx";
-import Certification from "./User/pages/Certifications/Certifications.jsx";
+import Certification from "./User/pages/Certification/Certification.jsx";
+import { Navigate } from "react-router-dom";
 // Admin components
 import AdminVerificationPage from "./User/pages/Admin-Verification/Admin.jsx";
 import AdminLayout from "./Admin/AdminLayout";
@@ -210,6 +211,9 @@ export default function App() {
             <Route path="orderDetails" element={<OrderDetails />} />
             {/* Order details route */}
             <Route path="myorders" element={<MyOrders />} />
+            {/* Backward-compatibility redirects */}
+            <Route path="my-orders" element={<Navigate to="/myorders" replace />} />
+            <Route path="myOrders" element={<Navigate to="/myorders" replace />} />
             {/* My orders route */}
             <Route path="checkout" element={<Checkout />} />
             {/* Checkout route */}
@@ -239,7 +243,7 @@ export default function App() {
             <Route path="profile" element={<ProfilePage />} />
             {/* Dashboard Profile route */}
           </Route>
-          {/* Certifications page route */}
+          {/* Certification page route */}
           <Route path="certification" element={<Certification />} />
           {/* 404 Error page route */}
           <Route path="*" element={<Error />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Route, Routes } from "react-router-dom";
+import { Route, Routes, Navigate } from "react-router-dom";
 import { AuthProvider } from "./context/AuthContext";
 
 // User components
@@ -41,7 +41,6 @@ import Shipping from "./User/pages/Shipping/shipping";
 import GiftCard from "./User/pages/Gift-Card/gift-card.jsx";
 import Payment_Policy from "./User/pages/Payment-Policy/payment-policy.jsx";
 import Certification from "./User/pages/Certification/Certification.jsx";
-import { Navigate } from "react-router-dom";
 // Admin components
 import AdminVerificationPage from "./User/pages/Admin-Verification/Admin.jsx";
 import AdminLayout from "./Admin/AdminLayout";
@@ -188,6 +187,8 @@ export default function App() {
           <Route path="payment-policy" element={<Payment_Policy />} />
           {/* Return and Cancellation page route */}
           <Route path="epr-compliance" element={<EPR_Page />} /> {/* EPR page route */}
+          {/* Backward-compat: legacy URL */}
+          <Route path="epr" element={<Navigate to="/epr-compliance" replace />} />
           <Route path="career" element={<CareerPage />} />
           <Route path="service" element={<ServicePage />} />
           <Route path="shipping" element={<Shipping />} />
@@ -245,6 +246,8 @@ export default function App() {
           </Route>
           {/* Certification page route */}
           <Route path="certification" element={<Certification />} />
+          {/* Backward-compat: legacy URL */}
+          <Route path="certificate" element={<Navigate to="/certification" replace />} />
           {/* 404 Error page route */}
           <Route path="*" element={<Error />} />
         </Route>

--- a/src/User/pages/Certification/Certification.jsx
+++ b/src/User/pages/Certification/Certification.jsx
@@ -5,6 +5,8 @@ import jsPDF from "jspdf";
 import Certificate from "../../../assets/images/Certificate.png";
 import Swal from 'sweetalert2';
 import confetti from 'canvas-confetti';
+import { Route, Routes, Navigate } from "react-router-dom";
+
 
 function Certification() {
   const [githubUsername, setGithubUsername] = useState("");

--- a/src/User/pages/Order/Cart.jsx
+++ b/src/User/pages/Order/Cart.jsx
@@ -78,7 +78,7 @@ const Breadcrumbs = () => (
       Cart
     </Link>
     <span>&gt;</span>
-    <Link to="/myOrders" className="hover:underline">
+    <Link to="/myorders" className="hover:underline">
       My Orders
     </Link>
     <span>&gt;</span>

--- a/src/User/pages/Order/MyOrders.jsx
+++ b/src/User/pages/Order/MyOrders.jsx
@@ -100,7 +100,7 @@ const Breadcrumbs = () => (
       Cart
     </Link>{" "}
     &gt;
-    <Link to="/myOrders" className="hover:underline">
+    <Link to="/myorders" className="hover:underline">
       My Orders
     </Link>{" "}
     &gt;

--- a/src/User/pages/Order/Orderdetails.jsx
+++ b/src/User/pages/Order/Orderdetails.jsx
@@ -44,7 +44,7 @@ const Breadcrumbs = () => (
       Cart
     </Link>{" "}
     &gt;
-    <Link to="/myOrders" className="hover:underline">
+    <Link to="/myorders" className="hover:underline">
       My Orders
     </Link>{" "}
     &gt;


### PR DESCRIPTION
## Fixes Issue

- #2614  fixed

## Changes proposed

Changed all the incorrect path naming ( certification, myorder, epr-compliance)

## Screenshots

<img width="1872" height="840" alt="image" src="https://github.com/user-attachments/assets/1c1e3382-510f-4281-8a6d-9cde1da82225" />


## Note to reviewers

Certification page might need some styling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated public routes for clearer navigation:
    * EPR page is now at /epr-compliance (legacy /epr redirects to new path).
    * My Orders is now at /myorders (legacy /my-orders and /myOrders redirect).
    * Certification page is now at /certification (legacy /certificate redirects).
  * Breadcrumbs and in-app links updated to use the new /myorders path.

* **Chores**
  * Standardized visible names/aliases and a label change: "Certifications" → "Certification".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->