### PR TITLE
Fix: rating filter now shows only exact star matches across categories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "react-cookie-consent": "^9.0.0",
         "react-ctrl-f": "^0.0.4",
         "react-dom": "^18.2.0",
-        "react-helmet": "^6.1.0",
         "react-helmet-async": "^2.0.5",
         "react-hot-toast": "^2.5.2",
         "react-icons": "^5.3.0",
@@ -14986,21 +14985,6 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
-    "node_modules/react-helmet": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
-      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.7.2",
-        "react-fast-compare": "^3.1.1",
-        "react-side-effect": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.3.0"
-      }
-    },
     "node_modules/react-helmet-async": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-2.0.5.tgz",
@@ -15117,14 +15101,6 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/react-side-effect": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
-      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
-      "peerDependencies": {
-        "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-slick": {

--- a/src/User/components/Popular_Categories/Filters.jsx
+++ b/src/User/components/Popular_Categories/Filters.jsx
@@ -40,15 +40,15 @@ function Filters({
           onChange={(e) => setPriceFilter(e.target.value)}
         />
         {/* Filter section for Rating */}
-        <FilterSection
-          title="Rating"
-          options={["1", "2", "3", "4", "5"]}
-          onChange={(e) => {
-            const value = parseInt(e.target.value, 10); //converting into int from decimal
-            setRatingFilter(Number.isNaN(value) ? 0.00 : value); //applying condition for rating or higher
-          }
-        }  
-        />
+<FilterSection
+  title="Rating"
+  options={["1", "2", "3", "4", "5"]}
+  onChange={(e) => {
+    const value = parseInt(e.target.value, 10);
+    setRatingFilter(Number.isNaN(value) ? null : value); // null means "All"
+  }}
+/>
+
       </div>
     </aside>
   );

--- a/src/User/pages/Latest_in_the_Market/ArtSupplies.jsx
+++ b/src/User/pages/Latest_in_the_Market/ArtSupplies.jsx
@@ -4,6 +4,8 @@ import ProductGrid from "../../components/Popular_Categories/ProductGrid";
 import toast from "react-hot-toast";
 import axios from "axios";
 import { Helmet } from "react-helmet-async";
+import { normalizeAndFilterByRating } from "../../utils/productFilters";
+
 
 
 
@@ -35,7 +37,7 @@ function ArtSupplies() {
               image: product.images[0] || "",
               discountPercentage: product.discountPercentage,
               rating: {
-                rate: product.rating,
+                rate: Math.round(product.rating),
                 count: product.reviews ? product.reviews.length : 0,
               },
             }));
@@ -72,11 +74,8 @@ function ArtSupplies() {
           (product) => product.price <= parseInt(priceFilter)
         );
       }
-      if (ratingFilter) {
-        updatedProducts = updatedProducts.filter(
-          (product) => Math.round(product.rating.rate) === ratingFilter
-        );
-      }
+     updatedProducts = normalizeAndFilterByRating(updatedProducts, ratingFilter);
+
       setFilteredProducts(updatedProducts);
     };
 

--- a/src/User/pages/Latest_in_the_Market/ArtSupplies.jsx
+++ b/src/User/pages/Latest_in_the_Market/ArtSupplies.jsx
@@ -74,7 +74,7 @@ function ArtSupplies() {
       }
       if (ratingFilter) {
         updatedProducts = updatedProducts.filter(
-          (product) => Math.round(product.rating.rate) >= ratingFilter
+          (product) => Math.round(product.rating.rate) === ratingFilter
         );
       }
       setFilteredProducts(updatedProducts);

--- a/src/User/pages/Latest_in_the_Market/BambooProducts.jsx
+++ b/src/User/pages/Latest_in_the_Market/BambooProducts.jsx
@@ -35,7 +35,7 @@ function BambooProducts() {
               image: product.images[0] || "",
               discountPercentage: product.discountPercentage,
               rating: {
-                rate: product.rating,
+                rate: Math.round(product.rating),
                 count: product.reviews ? product.reviews.length : 0,
               },
             }));
@@ -74,7 +74,7 @@ function BambooProducts() {
       }
       if (ratingFilter) {
         updatedProducts = updatedProducts.filter(
-          (product) => Math.round(product.rating.rate) >= ratingFilter
+          (product) => product.rating.rate === ratingFilter
         );
       }
       setFilteredProducts(updatedProducts);

--- a/src/User/pages/Latest_in_the_Market/BambooProducts.jsx
+++ b/src/User/pages/Latest_in_the_Market/BambooProducts.jsx
@@ -4,6 +4,7 @@ import ProductGrid from "../../components/Popular_Categories/ProductGrid";
 import toast from "react-hot-toast";
 import axios from "axios";
 import { Helmet } from "react-helmet-async";
+import { normalizeAndFilterByRating } from "../../utils/productFilters";
 
 
 
@@ -72,11 +73,8 @@ function BambooProducts() {
           (product) => product.price <= parseInt(priceFilter)
         );
       }
-      if (ratingFilter) {
-        updatedProducts = updatedProducts.filter(
-          (product) => product.rating.rate === ratingFilter
-        );
-      }
+      updatedProducts = normalizeAndFilterByRating(updatedProducts, ratingFilter);
+
       setFilteredProducts(updatedProducts);
     };
 

--- a/src/User/pages/Latest_in_the_Market/CeramicDinnerware.jsx
+++ b/src/User/pages/Latest_in_the_Market/CeramicDinnerware.jsx
@@ -35,7 +35,7 @@ function CeramicDinnerware() {
               image: product.images[0] || "",
               discountPercentage: product.discountPercentage,
               rating: {
-                rate: product.rating,
+                rate:  Math.round(product.rating),
                 count: product.reviews ? product.reviews.length : 0,
               },
             }));
@@ -74,7 +74,7 @@ function CeramicDinnerware() {
       }
       if (ratingFilter) {
         updatedProducts = updatedProducts.filter(
-          (product) => Math.round(product.rating.rate) >= ratingFilter
+          (product) => product.rating.rate === ratingFilter
         );
       }
       setFilteredProducts(updatedProducts);

--- a/src/User/pages/Latest_in_the_Market/CeramicDinnerware.jsx
+++ b/src/User/pages/Latest_in_the_Market/CeramicDinnerware.jsx
@@ -4,6 +4,7 @@ import ProductGrid from "../../components/Popular_Categories/ProductGrid";
 import toast from "react-hot-toast";
 import axios from "axios";
 import { Helmet } from "react-helmet-async";
+import { normalizeAndFilterByRating } from "../../utils/productFilters";
 
 
 
@@ -72,11 +73,8 @@ function CeramicDinnerware() {
           (product) => product.price <= parseInt(priceFilter)
         );
       }
-      if (ratingFilter) {
-        updatedProducts = updatedProducts.filter(
-          (product) => product.rating.rate === ratingFilter
-        );
-      }
+     updatedProducts = normalizeAndFilterByRating(updatedProducts, ratingFilter);
+
       setFilteredProducts(updatedProducts);
     };
 

--- a/src/User/pages/Latest_in_the_Market/HandMadeSoaps.jsx
+++ b/src/User/pages/Latest_in_the_Market/HandMadeSoaps.jsx
@@ -4,6 +4,7 @@ import ProductGrid from "../../components/Popular_Categories/ProductGrid";
 import toast from "react-hot-toast";
 import axios from "axios";
 import { Helmet } from "react-helmet-async";
+import { normalizeAndFilterByRating } from "../../utils/productFilters";
 
 
 
@@ -71,11 +72,8 @@ function HandMadeSoaps() {
           (product) => product.price <= parseInt(priceFilter)
         );
       }
-      if (ratingFilter) {
-        updatedProducts = updatedProducts.filter(
-          (product) => product.rating.rate === ratingFilter
-        );
-      }
+      updatedProducts = normalizeAndFilterByRating(updatedProducts, ratingFilter);
+
       setFilteredProducts(updatedProducts);
     };
 

--- a/src/User/pages/Latest_in_the_Market/HandMadeSoaps.jsx
+++ b/src/User/pages/Latest_in_the_Market/HandMadeSoaps.jsx
@@ -34,7 +34,7 @@ function HandMadeSoaps() {
               image: product.images[0] || "",
               discountPercentage: product.discountPercentage,
               rating: {
-                rate: product.rating,
+                rate:  Math.round(product.rating),
                 count: product.reviews ? product.reviews.length : 0,
               },
             }));
@@ -73,7 +73,7 @@ function HandMadeSoaps() {
       }
       if (ratingFilter) {
         updatedProducts = updatedProducts.filter(
-          (product) => Math.round(product.rating.rate) >= ratingFilter
+          (product) => product.rating.rate === ratingFilter
         );
       }
       setFilteredProducts(updatedProducts);

--- a/src/User/pages/Latest_in_the_Market/NaturalCosmetics.jsx
+++ b/src/User/pages/Latest_in_the_Market/NaturalCosmetics.jsx
@@ -35,7 +35,7 @@ function NaturalCosmetics() {
               image: product.images[0] || "",
               discountPercentage: product.discountPercentage,
               rating: {
-                rate: product.rating,
+                rate:  Math.round(product.rating),
                 count: product.reviews ? product.reviews.length : 0,
               },
             }));
@@ -74,7 +74,7 @@ function NaturalCosmetics() {
       }
       if (ratingFilter) {
         updatedProducts = updatedProducts.filter(
-          (product) => Math.round(product.rating.rate) >= ratingFilter
+          (product) => product.rating.rate === ratingFilter
         );
       }
       setFilteredProducts(updatedProducts);

--- a/src/User/pages/Latest_in_the_Market/NaturalCosmetics.jsx
+++ b/src/User/pages/Latest_in_the_Market/NaturalCosmetics.jsx
@@ -4,6 +4,7 @@ import ProductGrid from "../../components/Popular_Categories/ProductGrid";
 import toast from "react-hot-toast";
 import axios from "axios";
 import { Helmet } from "react-helmet-async";
+import { normalizeAndFilterByRating } from "../../utils/productFilters";
 
 
 
@@ -72,11 +73,8 @@ function NaturalCosmetics() {
           (product) => product.price <= parseInt(priceFilter)
         );
       }
-      if (ratingFilter) {
-        updatedProducts = updatedProducts.filter(
-          (product) => product.rating.rate === ratingFilter
-        );
-      }
+     updatedProducts = normalizeAndFilterByRating(updatedProducts, ratingFilter);
+
       setFilteredProducts(updatedProducts);
     };
 

--- a/src/User/pages/Latest_in_the_Market/OrganicSoaps.jsx
+++ b/src/User/pages/Latest_in_the_Market/OrganicSoaps.jsx
@@ -35,7 +35,7 @@ function OrganicSoaps() {
               image: product.images[0] || "",
               discountPercentage: product.discountPercentage,
               rating: {
-                rate: product.rating,
+                rate:  Math.round(product.rating),
                 count: product.reviews ? product.reviews.length : 0,
               },
             }));
@@ -74,7 +74,7 @@ function OrganicSoaps() {
       }
       if (ratingFilter) {
         updatedProducts = updatedProducts.filter(
-          (product) => Math.round(product.rating.rate) >= ratingFilter
+          (product) => product.rating.rate === ratingFilter
         );
       }
       setFilteredProducts(updatedProducts);

--- a/src/User/pages/Latest_in_the_Market/OrganicSoaps.jsx
+++ b/src/User/pages/Latest_in_the_Market/OrganicSoaps.jsx
@@ -4,6 +4,7 @@ import ProductGrid from "../../components/Popular_Categories/ProductGrid";
 import toast from "react-hot-toast";
 import axios from "axios";
 import { Helmet } from "react-helmet-async";
+import { normalizeAndFilterByRating } from "../../utils/productFilters";
 
 
 
@@ -72,11 +73,8 @@ function OrganicSoaps() {
           (product) => product.price <= parseInt(priceFilter)
         );
       }
-      if (ratingFilter) {
-        updatedProducts = updatedProducts.filter(
-          (product) => product.rating.rate === ratingFilter
-        );
-      }
+     updatedProducts = normalizeAndFilterByRating(updatedProducts, ratingFilter);
+
       setFilteredProducts(updatedProducts);
     };
 

--- a/src/User/pages/Latest_in_the_Market/OrganicTea.jsx
+++ b/src/User/pages/Latest_in_the_Market/OrganicTea.jsx
@@ -4,6 +4,8 @@ import ProductGrid from "../../components/Popular_Categories/ProductGrid";
 import toast from "react-hot-toast";
 import axios from "axios";
 import { Helmet } from "react-helmet-async";
+import { normalizeAndFilterByRating } from "../../utils/productFilters";
+
 
 
 
@@ -71,11 +73,8 @@ function OrganicTea() {
           (product) => product.price <= parseInt(priceFilter)
         );
       }
-      if (ratingFilter) {
-        updatedProducts = updatedProducts.filter(
-          (product) => product.rating.rate === ratingFilter
-        );
-      }
+     updatedProducts = normalizeAndFilterByRating(updatedProducts, ratingFilter);
+
       setFilteredProducts(updatedProducts);
     };
 

--- a/src/User/pages/Latest_in_the_Market/OrganicTea.jsx
+++ b/src/User/pages/Latest_in_the_Market/OrganicTea.jsx
@@ -34,7 +34,7 @@ function OrganicTea() {
               image: product.images[0] || "",
               discountPercentage: product.discountPercentage,
               rating: {
-                rate: product.rating,
+                rate:  Math.round(product.rating),
                 count: product.reviews ? product.reviews.length : 0,
               },
             }));
@@ -73,7 +73,7 @@ function OrganicTea() {
       }
       if (ratingFilter) {
         updatedProducts = updatedProducts.filter(
-          (product) => Math.round(product.rating.rate) >= ratingFilter
+          (product) => product.rating.rate === ratingFilter
         );
       }
       setFilteredProducts(updatedProducts);

--- a/src/User/pages/Latest_in_the_Market/StorageBaskets.jsx
+++ b/src/User/pages/Latest_in_the_Market/StorageBaskets.jsx
@@ -4,6 +4,7 @@ import ProductGrid from "../../components/Popular_Categories/ProductGrid";
 import toast from "react-hot-toast";
 import axios from "axios";
 import { Helmet } from "react-helmet-async";
+import { normalizeAndFilterByRating } from "../../utils/productFilters";
 
 
 
@@ -71,11 +72,8 @@ function StorageBaskets() {
           (product) => product.price <= parseInt(priceFilter)
         );
       }
-      if (ratingFilter) {
-        updatedProducts = updatedProducts.filter(
-          (product) => product.rating.rate === ratingFilter
-        );
-      }
+      updatedProducts = normalizeAndFilterByRating(updatedProducts, ratingFilter);
+
       setFilteredProducts(updatedProducts);
     };
 

--- a/src/User/pages/Latest_in_the_Market/StorageBaskets.jsx
+++ b/src/User/pages/Latest_in_the_Market/StorageBaskets.jsx
@@ -34,7 +34,7 @@ function StorageBaskets() {
               image: product.images[0] || "",
               discountPercentage: product.discountPercentage,
               rating: {
-                rate: product.rating,
+                rate:  Math.round(product.rating),
                 count: product.reviews ? product.reviews.length : 0,
               },
             }));
@@ -73,7 +73,7 @@ function StorageBaskets() {
       }
       if (ratingFilter) {
         updatedProducts = updatedProducts.filter(
-          (product) => Math.round(product.rating.rate) >= ratingFilter
+          (product) => product.rating.rate === ratingFilter
         );
       }
       setFilteredProducts(updatedProducts);

--- a/src/User/pages/Popular_Categories/Beauty-Wellness.jsx
+++ b/src/User/pages/Popular_Categories/Beauty-Wellness.jsx
@@ -4,6 +4,8 @@ import ProductGrid from "../../components/Popular_Categories/ProductGrid";
 import toast from "react-hot-toast";
 import axios from "axios";
 import { Helmet } from "react-helmet-async";
+import { normalizeAndFilterByRating } from "../../utils/productFilters";
+
 
 
 function BeautyWellness() {
@@ -69,11 +71,8 @@ function BeautyWellness() {
           (product) => product.price <= parseInt(priceFilter)
         );
       }
-      if (ratingFilter) {
-        updatedProducts = updatedProducts.filter(
-          (product) => product.rating.rate === ratingFilter
-        );
-      }
+      updatedProducts = normalizeAndFilterByRating(updatedProducts, ratingFilter);
+
       setFilteredProducts(updatedProducts);
     };
 

--- a/src/User/pages/Popular_Categories/Beauty-Wellness.jsx
+++ b/src/User/pages/Popular_Categories/Beauty-Wellness.jsx
@@ -32,7 +32,7 @@ function BeautyWellness() {
               image: product.images[0] || "",
               discountPercentage: product.discountPercentage,
               rating: {
-                rate: product.rating,
+                rate:  Math.round(product.rating),
                 count: product.reviews ? product.reviews.length : 0,
               },
             }));
@@ -71,7 +71,7 @@ function BeautyWellness() {
       }
       if (ratingFilter) {
         updatedProducts = updatedProducts.filter(
-          (product) => Math.round(product.rating.rate) >= ratingFilter
+          (product) => product.rating.rate === ratingFilter
         );
       }
       setFilteredProducts(updatedProducts);

--- a/src/User/pages/Popular_Categories/Body-Care.jsx
+++ b/src/User/pages/Popular_Categories/Body-Care.jsx
@@ -32,7 +32,7 @@ function BodyCare() {
               image: product.images[0] || "",
               discountPercentage: product.discountPercentage,
               rating: {
-                rate: product.rating,
+                rate:  Math.round(product.rating),
                 count: product.reviews ? product.reviews.length : 0,
               },
             }));
@@ -71,7 +71,7 @@ function BodyCare() {
       }
       if (ratingFilter) {
         updatedProducts = updatedProducts.filter(
-          (product) => Math.round(product.rating.rate) >= ratingFilter
+          (product) => product.rating.rate === ratingFilter
         );
       }
       setFilteredProducts(updatedProducts);

--- a/src/User/pages/Popular_Categories/Body-Care.jsx
+++ b/src/User/pages/Popular_Categories/Body-Care.jsx
@@ -4,6 +4,8 @@ import ProductGrid from "../../components/Popular_Categories/ProductGrid";
 import toast from "react-hot-toast";
 import axios from "axios";
 import { Helmet } from "react-helmet-async";
+import { normalizeAndFilterByRating } from "../../utils/productFilters";
+
 
 
 function BodyCare() {
@@ -69,11 +71,8 @@ function BodyCare() {
           (product) => product.price <= parseInt(priceFilter)
         );
       }
-      if (ratingFilter) {
-        updatedProducts = updatedProducts.filter(
-          (product) => product.rating.rate === ratingFilter
-        );
-      }
+      updatedProducts = normalizeAndFilterByRating(updatedProducts, ratingFilter);
+
       setFilteredProducts(updatedProducts);
     };
 

--- a/src/User/pages/Popular_Categories/Customized-Gifts.jsx
+++ b/src/User/pages/Popular_Categories/Customized-Gifts.jsx
@@ -32,7 +32,7 @@ function CustomizedGifts() {
               image: product.images[0] || "",
               discountPercentage: product.discountPercentage,
               rating: {
-                rate: product.rating,
+                rate:  Math.round(product.rating),
                 count: product.reviews ? product.reviews.length : 0,
               },
             }));
@@ -71,7 +71,7 @@ function CustomizedGifts() {
       }
       if (ratingFilter) {
         updatedProducts = updatedProducts.filter(
-          (product) => Math.round(product.rating.rate) >= ratingFilter
+          (product) => product.rating.rate === ratingFilter
         );
       }
       setFilteredProducts(updatedProducts);

--- a/src/User/pages/Popular_Categories/Customized-Gifts.jsx
+++ b/src/User/pages/Popular_Categories/Customized-Gifts.jsx
@@ -4,6 +4,7 @@ import ProductGrid from "../../components/Popular_Categories/ProductGrid";
 import toast from "react-hot-toast";
 import axios from "axios";
 import { Helmet } from "react-helmet-async";
+import { normalizeAndFilterByRating } from "../../utils/productFilters";
 
 
 function CustomizedGifts() {
@@ -69,11 +70,7 @@ function CustomizedGifts() {
           (product) => product.price <= parseInt(priceFilter)
         );
       }
-      if (ratingFilter) {
-        updatedProducts = updatedProducts.filter(
-          (product) => product.rating.rate === ratingFilter
-        );
-      }
+       updatedProducts = normalizeAndFilterByRating(updatedProducts, ratingFilter);
       setFilteredProducts(updatedProducts);
     };
 

--- a/src/User/pages/Popular_Categories/Fashion-Accessories.jsx
+++ b/src/User/pages/Popular_Categories/Fashion-Accessories.jsx
@@ -4,6 +4,7 @@ import ProductGrid from "../../components/Popular_Categories/ProductGrid";
 import toast from "react-hot-toast";
 import axios from "axios";
 import { Helmet } from "react-helmet-async";
+import { normalizeAndFilterByRating } from "../../utils/productFilters";
 
 function FashionAccessories() {
   const [products, setProducts] = useState([]);
@@ -68,11 +69,8 @@ function FashionAccessories() {
           (product) => product.price <= parseInt(priceFilter)
         );
       }
-      if (ratingFilter) {
-        updatedProducts = updatedProducts.filter(
-          (product) => product.rating.rate === ratingFilter
-        );
-      }
+      updatedProducts = normalizeAndFilterByRating(updatedProducts, ratingFilter);
+
       setFilteredProducts(updatedProducts);
     };
 

--- a/src/User/pages/Popular_Categories/Fashion-Accessories.jsx
+++ b/src/User/pages/Popular_Categories/Fashion-Accessories.jsx
@@ -31,7 +31,7 @@ function FashionAccessories() {
               image: product.images[0] || "",
               discountPercentage: product.discountPercentage,
               rating: {
-                rate: product.rating,
+                rate: Math.round(product.rating),
                 count: product.reviews ? product.reviews.length : 0,
               },
             }));
@@ -70,7 +70,7 @@ function FashionAccessories() {
       }
       if (ratingFilter) {
         updatedProducts = updatedProducts.filter(
-          (product) => Math.round(product.rating.rate) >= ratingFilter
+          (product) => product.rating.rate === ratingFilter
         );
       }
       setFilteredProducts(updatedProducts);

--- a/src/User/pages/Popular_Categories/Food-Beverages.jsx
+++ b/src/User/pages/Popular_Categories/Food-Beverages.jsx
@@ -4,6 +4,7 @@ import ProductGrid from "../../components/Popular_Categories/ProductGrid";
 import toast from "react-hot-toast";
 import axios from "axios";
 import { Helmet } from "react-helmet-async";
+import { normalizeAndFilterByRating } from "../../utils/productFilters";
 
 
 function FoodBeverages() {
@@ -69,11 +70,8 @@ function FoodBeverages() {
           (product) => product.price <= parseInt(priceFilter)
         );
       }
-      if (ratingFilter) {
-        updatedProducts = updatedProducts.filter(
-          (product) => product.rating.rate === ratingFilter
-        );
-      }
+     updatedProducts = normalizeAndFilterByRating(updatedProducts, ratingFilter);
+
       setFilteredProducts(updatedProducts);
     };
 

--- a/src/User/pages/Popular_Categories/Food-Beverages.jsx
+++ b/src/User/pages/Popular_Categories/Food-Beverages.jsx
@@ -32,7 +32,7 @@ function FoodBeverages() {
               image: product.images[0] || "",
               discountPercentage: product.discountPercentage,
               rating: {
-                rate: product.rating,
+                rate:  Math.round(product.rating),
                 count: product.reviews ? product.reviews.length : 0,
               },
             }));
@@ -71,7 +71,7 @@ function FoodBeverages() {
       }
       if (ratingFilter) {
         updatedProducts = updatedProducts.filter(
-          (product) => Math.round(product.rating.rate) >= ratingFilter
+          (product) => product.rating.rate === ratingFilter
         );
       }
       setFilteredProducts(updatedProducts);

--- a/src/User/pages/Popular_Categories/Furniture-Decor.jsx
+++ b/src/User/pages/Popular_Categories/Furniture-Decor.jsx
@@ -33,7 +33,7 @@ function FurnitureDecor() {
               image: product.images[0] || "",
               discountPercentage: product.discountPercentage,
               rating: {
-                rate: product.rating,
+                rate:  Math.round(product.rating),
                 count: product.reviews ? product.reviews.length : 0,
               },
             }));
@@ -72,7 +72,7 @@ function FurnitureDecor() {
       }
       if (ratingFilter) {
         updatedProducts = updatedProducts.filter(
-          (product) => Math.round(product.rating.rate) >= ratingFilter
+          (product) => product.rating.rate === ratingFilter
         );
       }
       setFilteredProducts(updatedProducts);

--- a/src/User/pages/Popular_Categories/Furniture-Decor.jsx
+++ b/src/User/pages/Popular_Categories/Furniture-Decor.jsx
@@ -4,6 +4,7 @@ import ProductGrid from "../../components/Popular_Categories/ProductGrid";
 import toast from "react-hot-toast";
 import axios from "axios";
 import { Helmet } from "react-helmet-async";
+import { normalizeAndFilterByRating } from "../../utils/productFilters";
 
 
 
@@ -70,11 +71,8 @@ function FurnitureDecor() {
           (product) => product.price <= parseInt(priceFilter)
         );
       }
-      if (ratingFilter) {
-        updatedProducts = updatedProducts.filter(
-          (product) => product.rating.rate === ratingFilter
-        );
-      }
+      updatedProducts = normalizeAndFilterByRating(updatedProducts, ratingFilter);
+
       setFilteredProducts(updatedProducts);
     };
 

--- a/src/User/pages/Popular_Categories/Health-Supplements.jsx
+++ b/src/User/pages/Popular_Categories/Health-Supplements.jsx
@@ -33,7 +33,7 @@ function HealthSupplements() {
               image: product.images[0] || "",
               discountPercentage: product.discountPercentage,
               rating: {
-                rate: product.rating,
+                rate:  Math.round(product.rating),
                 count: product.reviews ? product.reviews.length : 0,
               },
             }));
@@ -72,7 +72,7 @@ function HealthSupplements() {
       }
       if (ratingFilter) {
         updatedProducts = updatedProducts.filter(
-          (product) => Math.round(product.rating.rate) >= ratingFilter
+          (product) => product.rating.rate === ratingFilter
         );
       }
       setFilteredProducts(updatedProducts);

--- a/src/User/pages/Popular_Categories/Health-Supplements.jsx
+++ b/src/User/pages/Popular_Categories/Health-Supplements.jsx
@@ -4,6 +4,7 @@ import ProductGrid from "../../components/Popular_Categories/ProductGrid";
 import toast from "react-hot-toast";
 import axios from "axios";
 import { Helmet } from "react-helmet-async";
+import { normalizeAndFilterByRating } from "../../utils/productFilters";
 
 
 
@@ -70,11 +71,8 @@ function HealthSupplements() {
           (product) => product.price <= parseInt(priceFilter)
         );
       }
-      if (ratingFilter) {
-        updatedProducts = updatedProducts.filter(
-          (product) => product.rating.rate === ratingFilter
-        );
-      }
+     updatedProducts = normalizeAndFilterByRating(updatedProducts, ratingFilter);
+
       setFilteredProducts(updatedProducts);
     };
 

--- a/src/User/pages/Popular_Categories/Popular_Categories.jsx
+++ b/src/User/pages/Popular_Categories/Popular_Categories.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Navbar from "../../components/Navbar/UserNavbar";
 
+
 function Popular_Categories() {
   return (
     <div>

--- a/src/User/pages/Popular_Categories/Printing-Stationery.jsx
+++ b/src/User/pages/Popular_Categories/Printing-Stationery.jsx
@@ -73,7 +73,7 @@ function PrintingStationery() {
       }
       if (ratingFilter) {
         updatedProducts = updatedProducts.filter(
-          (product) => Math.round(product.rating.rate) >= ratingFilter
+          (product) => Math.round(product.rating.rate) === ratingFilter
         );
       }
       setFilteredProducts(updatedProducts);

--- a/src/User/pages/Popular_Categories/Printing-Stationery.jsx
+++ b/src/User/pages/Popular_Categories/Printing-Stationery.jsx
@@ -4,6 +4,7 @@ import ProductGrid from "../../components/Popular_Categories/ProductGrid";
 import toast from "react-hot-toast";
 import axios from "axios";
 import { Helmet } from "react-helmet-async";
+import { normalizeAndFilterByRating } from "../../utils/productFilters";
 
 
 
@@ -34,7 +35,7 @@ function PrintingStationery() {
               image: product.images[0] || "",
               discountPercentage: product.discountPercentage,
               rating: {
-                rate: product.rating,
+                rate: Math.round(product.rating),
                 count: product.reviews ? product.reviews.length : 0,
               },
             }));
@@ -71,11 +72,8 @@ function PrintingStationery() {
           (product) => product.price <= parseInt(priceFilter)
         );
       }
-      if (ratingFilter) {
-        updatedProducts = updatedProducts.filter(
-          (product) => Math.round(product.rating.rate) === ratingFilter
-        );
-      }
+      updatedProducts = normalizeAndFilterByRating(updatedProducts, ratingFilter);
+
       setFilteredProducts(updatedProducts);
     };
 

--- a/src/User/utils/productFilters.js
+++ b/src/User/utils/productFilters.js
@@ -1,0 +1,9 @@
+export function normalizeAndFilterByRating(products, ratingFilter) {
+  const ratingNum = Number(ratingFilter);
+  if (!Number.isFinite(ratingNum) || ratingNum <= 0) return products;
+
+  return products.filter(product => {
+    const productRating = Math.round(Number(product.rating?.rate || 0));
+    return productRating === ratingNum;
+  });
+}


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue
Closes #2629

## Changes proposed
- Normalized product ratings using `Math.round()` at mapping stage.
- Updated filter logic to ensure exact star matches (3 starred shows only products rated 3, not 3.5 or above).
- Applied fix consistently across all product/category pages.

## Screenshots

### Before
<img width="952" height="365" alt="image" src="https://github.com/user-attachments/assets/06631ff8-c4c7-49c3-b439-4bbbbfe13957" />

### After
<img width="1919" height="760" alt="Screenshot 2025-08-29 022131" src="https://github.com/user-attachments/assets/9581ca07-3404-4828-afd8-b59ab3a8259b" />


## Note to reviewers
- Verified locally in categories like Art Supplies, Bamboo Products, Body Care, etc.
- Please check if the new filter behavior matches the expected functionality.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ratings are standardized to whole-star values across listings for consistent display and filtering.
  * Rating-based filtering now uses the standardized values and selects exact star matches (not "at least").

* **Affected Areas**
  * Applies across Latest in the Market and Popular Categories (multiple sections).

* **Style/UX**
  * Rating selector now treats an invalid selection as "All" (no rating filter).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->