### PR TITLE
Add general issue template for GitHub issues

### DIFF
--- a/.github/ISSUES_TEMPLATE/issue_template.md
+++ b/.github/ISSUES_TEMPLATE/issue_template.md
@@ -1,0 +1,50 @@
+---
+name: 📝 General Issue Template
+about: Report a bug, suggest a feature, or request an enhancement
+title: "[TYPE] Short issue summary"
+labels: []
+assignees: ""
+---
+
+## 🧭 Issue Type
+<!-- Please select one -->
+- [ ] 🐞 Bug
+- [ ] 💡 Feature Request
+- [ ] 🚀 Enhancement
+
+---
+
+## 📝 Description
+<!-- A clear and concise description of the issue. -->
+
+---
+
+## 🔍 Steps to Reproduce (for bugs)
+1. 
+2. 
+3. 
+
+---
+
+## ✅ Expected Behavior
+<!-- What did you expect to happen? -->
+
+---
+
+## 🧩 Actual Behavior (for bugs)
+<!-- What actually happened? Include screenshots or logs if applicable. -->
+
+---
+
+## 💡 Suggested Solution / Implementation
+<!-- If you have an idea for how to fix or improve it, describe it here. -->
+
+---
+
+## 🧰 Additional Context
+<!-- Add any other context, links, or screenshots about the issue here. -->
+
+---
+
+### 🏷️ Notes for Maintainers
+<!-- Optional: Mention any labels or reviewers you recommend. -->


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

<!-- List all the proposed changes in your PR -->

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new issue template to standardize issue submissions with predefined sections for issue type, description, reproduction steps, expected/actual behavior, suggested solutions, additional context, and maintainer notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->